### PR TITLE
add confirmation dialogs in collab notes when clicking buttons that have destructive actions

### DIFF
--- a/frontend/nodejs/views/notes/index.ejs
+++ b/frontend/nodejs/views/notes/index.ejs
@@ -20,8 +20,12 @@
         </div>
         <div class="col-md-6">
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-                <button id="joinButton" class="btn btn-success">Join Collab Session</button>
-                <button id="sessionButton" class="btn btn-outline-success" disabled>Create Collab Session</button>
+                <div id="joinWrapper">
+                    <button id="joinButton" class="btn btn-success">Join Collab Session</button>
+                </div>
+                <div id="sessionWrapper">
+                    <button id="sessionButton" class="btn btn-outline-success">Create Collab Session</button>
+                </div>
             </div>
         </div>
     </div>

--- a/frontend/nodejs/views/notes/partials/components/UI.ejs
+++ b/frontend/nodejs/views/notes/partials/components/UI.ejs
@@ -8,8 +8,43 @@
             this.initializeSession();
         },
 
-        toggleSessionButton(enable) {
-            $('#sessionButton').prop('disabled', !!State.currentSession || !enable);
+        showConfirmAlert(title, text, confirmCallback) {
+            return this.showAlert({
+                title,
+                text,
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Yes',
+                cancelButtonText: 'No',
+            }).then(result => {
+                if (result.isConfirmed) {
+                    confirmCallback();
+                }
+            });
+        },
+
+        showVersionAlert(title, preConfirmCallback) {
+            if (!State.currentID) {
+                return this.showAlert({
+                    icon: 'warning',
+                    title: 'No Note Selected',
+                    text: 'Please create or load a note first'
+                });
+            }
+
+            return this.showAlert({
+                title,
+                input: "text",
+                showCloseButton: true,
+                width: '600px',
+                preConfirm: preConfirmCallback
+            });
+        },
+
+        // Check if the URL contains specific parameters
+        hasUrlParameter(param) {
+            const urlParams = new URLSearchParams(window.location.search);
+            return urlParams.has(param);
         },
 
         toggleEditorOverlay(hide) {
@@ -67,9 +102,33 @@
             $('#loadNoteOverlayButton').on('click', () => $('#existingNoteSweetAlertButton').click());
 
             // Primary functionality buttons
-            $('#newNoteButton').on('click', NoteManager.createNewNote);
+            $('#newNoteButton').on('click', () => {
+                // Show confirm box only if URL has 'id' parameter
+                if (this.hasUrlParameter('id')) {
+                    this.showConfirmAlert(
+                        'Are you sure you want to start a new note?',
+                        'Make sure to save your note ID first',
+                        NoteManager.createNewNote
+                    );
+                } else {
+                    NoteManager.createNewNote();
+                }
+            });
             $('#existingNoteSweetAlertButton').on('click', NoteManager.promptLoadExistingNote);
-            $('#sessionButton').on('click', SessionManager.createSession);
+            
+            // Create Collab Session button confirmation
+            $('#sessionButton').on('click', () => {
+                // Show confirm box only if URL has 'session' parameter
+                if (this.hasUrlParameter('session')) {
+                    this.showConfirmAlert(
+                        'Are you sure you want to start a new Collab Session?',
+                        'Your current session will be lost',
+                        SessionManager.createSession
+                    );
+                } else {
+                    SessionManager.createSession();
+                }
+            });
             $('#joinButton').on('click', SessionManager.promptJoinSession);
             $('#versionControlAlertButton').on('click', VersionManager.promptViewVersion);
             $('#currentNoteButton').on('click', VersionManager.returnToCurrentVersion);

--- a/frontend/nodejs/views/notes/partials/components/noteManager.ejs
+++ b/frontend/nodejs/views/notes/partials/components/noteManager.ejs
@@ -20,7 +20,6 @@
                 window.history.pushState("", "", window.location.pathname + `?id=${data.id}`);
 
                 Editor.setContent(data);
-                UI.toggleSessionButton(true);
                 UI.toggleEditorOverlay(true);
             } catch (error) {
                 console.error('Error creating new note:', error);
@@ -32,7 +31,6 @@
                 const note = await API.getExistingNote(result);
                 window.history.pushState("", "", window.location.pathname + `?id=${note.id}`);
                 Editor.setContent(note);
-                UI.toggleSessionButton(true);
                 UI.toggleEditorOverlay(true);
             });
         },
@@ -42,7 +40,6 @@
                 const note = await API.getExistingNote(noteId);
                 window.history.pushState("", "", window.location.pathname + `?id=${note.id}`);
                 Editor.setContent(note);
-                UI.toggleSessionButton(true);
                 UI.toggleEditorOverlay(true);
             } catch (error) {
                 console.error('Error loading note:', error);

--- a/frontend/nodejs/views/notes/partials/components/sessionManager.ejs
+++ b/frontend/nodejs/views/notes/partials/components/sessionManager.ejs
@@ -17,7 +17,6 @@
 
                     WebSocketManager.connect();
 
-                    UI.toggleSessionButton(true);
 
                     WebSocketManager.sendMessage('newSession', sessionCode);
                 } catch (error) {
@@ -52,7 +51,7 @@
                     UI.updateSessionDisplay(sessionCode, true);
 
                     WebSocketManager.connect();
-                    UI.toggleSessionButton(true);
+                    //UI.toggleSessionButton(true);
                     UI.toggleEditorOverlay(true);
                 }
             } catch (error) {
@@ -76,7 +75,7 @@
                     window.history.pushState("", "", window.location.pathname + `?id=${data.note.id}` + `&session=${State.currentSession}`);
                 }
 
-                UI.toggleSessionButton(true);
+                //UI.toggleSessionButton(true);
                 UI.toggleEditorOverlay(true);
             } catch (error) {
                 console.error('Error loading session note:', error);

--- a/frontend/nodejs/views/shared/layout.ejs
+++ b/frontend/nodejs/views/shared/layout.ejs
@@ -54,6 +54,19 @@
     -  > appendToHeading(): Allows adding any text to the document <title> 
     -->
     <script>
+        $(function () {
+            $(document).on('mouseenter', '[data-toggle="tooltip"]', function() {
+                var placement = $(this).data('placement');
+                // Initialize tooltip with the placement option if defined
+                $(this).tooltip({
+                    placement: placement || 'top'  // Default to 'top' if no placement is specified
+                }).tooltip('show');
+            });
+
+            $(document).on('shown.bs.tooltip', '[data-toggle="tooltip"]', function () {
+                $(this).tooltip();
+            });
+        })
 
         /*
         * Can be ran from any .html page that is including this layout.


### PR DESCRIPTION
- add tooltip code sitewide for bootstrap tooltips (unrelated but good for future use)
- add conditional confirmation dialogs in collab notes for when clicking buttons that leave existing sessions/notes

![image](https://github.com/user-attachments/assets/20112641-e03a-4905-9372-03a07ba70903)
![image](https://github.com/user-attachments/assets/53b375e1-1c39-4c35-a32f-efc2ced486ba)
![image](https://github.com/user-attachments/assets/ccbb24b0-005a-4c28-a6d6-ed132a7dd45c)
